### PR TITLE
Format maintainer list in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,20 +6,20 @@ This document contains a list of maintainers in this repo. See [RESPONSIBILITIES
 
 ## Current Maintainers
 
-|Maintainer	|GitHub ID	|Affiliation	|
+| Maintainer	| GitHub ID	| Affiliation	|
 |---	|---	|---	|
-|Darin	McAdams|D-McAdams	|SPIRL	|
-|Emina Torlak	|emina	|Amazon	|
-|Shaobo He	|shaobo-he-aws	|Amazon	|
-|Craig Disselkoen	|cdisselkoen	|Amazon	|
-|John Kastner 	|john-h-kastner-aws	|Amazon	|
-|Adrian Palacios |adpaco-aws |Amazon |
-|Charlie Murphy |chaluli |Amazon |
-|Katherine Hough |katherine-hough |Amazon |
-|Liana Hadarean |lianah |Amazon |
-|Andrew Gwozdziewycz |apg |StrongDM |
-|Ali Dowair |adowair |StrongDM |
-|Phil Hassey |philhassey |StrongDM |
-|Patrick Jakubowski |patjak-dev |StrongDM |
-|Eitan Revach |eitan-revach |Cloudinary |
-|Tom Paulus |tpaulus |Cloudflare |
+| Darin	McAdams| D-McAdams	| SPIRL	|
+| Emina Torlak	| emina	| Amazon	|
+| Shaobo He	| shaobo-he-aws	| Amazon	|
+| Craig Disselkoen	| cdisselkoen	| Amazon	|
+| John Kastner 	| john-h-kastner-aws	| Amazon	|
+| Adrian Palacios | adpaco-aws | Amazon |
+| Charlie Murphy | chaluli | Amazon |
+| Katherine Hough | katherine-hough | Amazon |
+| Liana Hadarean | lianah | Amazon |
+| Andrew Gwozdziewycz | apg | StrongDM |
+| Ali Dowair | adowair | StrongDM |
+| Phil Hassey | philhassey | StrongDM |
+| Patrick Jakubowski | patjak-dev | StrongDM |
+| Eitan Revach | eitan-revach | Cloudinary |
+| Tom Paulus | tpaulus | Cloudflare |


### PR DESCRIPTION
Hi Cedar Maintainers,

I work on the CNCF Projects team with @jeefy and @krook, and I have a small, purely formatting-related request that would help with onboarding and automation across CNCF projects.

We automatically process MAINTAINERS.md files across CNCF repositories to extract the list of project maintainers. This PR makes a very minor adjustment that simplifies parsing while keeping the file human-readable and semantically identical.

Description of the change:

Add a space between the Markdown table cell delimiter (|) and the GitHub ID.

Apply the same spacing consistently across all table cells for uniform formatting.

This makes it easier for us to reliably extract GitHub IDs (which we use as stable identifiers for maintainers across CNCF systems) while preserving the intent and structure of the file.

Thanks very much for your time and for maintaining Cedar — I appreciate you taking a look.