### PR TITLE
update README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -66,7 +66,7 @@ See [NOTICE](NOTICE) for details.
 
 ## Trademark
 
-Cedar is a CNCF sandbox project. If publishing software using Cedar, you are not required to attribute. However, if you’d like to, we encourage you to use the language below.
+Cedar is a trademark of [The Linux Foundation](https://www.linuxfoundation.org/legal/trademark-usage). If publishing software using Cedar, you are not required to attribute. However, if you’d like to, we encourage you to use the language below.
 
 
 |Do:	|Don't:	|

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
 
 ## Welcome!
 
-**Cedar** is an open source policy language and evaluation engine. Cedar enables developers to express fine-grained permissions as easy-to-understand policies enforced in their applications, and decouple access control from application logic. Cedar supports common authorization models such as role-based access control and attribute-based access control. It is the first policy language built from the ground up to be verified formally by using automated reasoning, and tested rigorously using differential random testing. 
+**Cedar** is an open source policy language and evaluation engine. Cedar enables developers to express fine-grained permissions as easy-to-understand policies enforced in their applications, and decouple access control from application logic. Cedar supports common authorization models such as role-based access control and attribute-based access control. It is the first policy language built from the ground up to be verified formally by using automated reasoning, and tested rigorously using differential random testing.
 
 
 ## Project Resources
@@ -15,32 +15,34 @@
 
 ## Repositories
 
-* **[cedar](https://github.com/cedar-policy/cedar)**  
+* **[cedar](https://github.com/cedar-policy/cedar)**
 Cedar SDK including the authorization engine, validator, policy formatter, and CLI
-* **[cedar-docs](https://github.com/cedar-policy/cedar-docs)**  
+* **[cedar-docs](https://github.com/cedar-policy/cedar-docs)**
 Houses documentation for all cedar projects
-* **[cedar-examples](https://github.com/cedar-policy/cedar-examples)**  
+* **[cedar-examples](https://github.com/cedar-policy/cedar-examples)**
 Example applications using the Cedar language and SDK
-* **[cedar-spec](https://github.com/cedar-policy/cedar-spec)**  
+* **[cedar-spec](https://github.com/cedar-policy/cedar-spec)**
 Formal Lean specification for the Cedar language as well as the differential testing/property-based testing framework
-* **[cedar-local-agent](https://github.com/cedar-policy/cedar-local-agent)**  
+* **[cedar-local-agent](https://github.com/cedar-policy/cedar-local-agent)**
 Configurable cache for Cedar policies and entities
-* **[cedar-go](https://github.com/cedar-policy/cedar-go)**  
+* **[cedar-go](https://github.com/cedar-policy/cedar-go)**
 Cedar Go implementation
-* **[cedar-java](https://github.com/cedar-policy/cedar-java)**  
+* **[cedar-java](https://github.com/cedar-policy/cedar-java)**
 Java language bindings for Cedar
-* **[cedar-awesome](https://github.com/cedar-policy/cedar-awesome)**  
+* **[cedar-awesome](https://github.com/cedar-policy/cedar-awesome)**
 Curated list of awesome Cedar related tools and articles.
-* **[rfcs](https://github.com/cedar-policy/rfcs)**  
+* **[rfcs](https://github.com/cedar-policy/rfcs)**
 Request For Comments (RFC) for Cedar
-* **[vscode-cedar](https://github.com/cedar-policy/vscode-cedar)**  
+* **[vscode-cedar](https://github.com/cedar-policy/vscode-cedar)**
 Cedar policy language extension for Visual Studio Code
-* **[cedar-integration-tests](https://github.com/cedar-policy/cedar-integration-tests)**  
+* **[cedar-integration-tests](https://github.com/cedar-policy/cedar-integration-tests)**
 Cedar integration tests
-* **[highlightjs-cedar](https://github.com/cedar-policy/highlightjs-cedar)**  
+* **[highlightjs-cedar](https://github.com/cedar-policy/highlightjs-cedar)**
 highlight.js support for Cedar policy language
-* **[prism-cedar](https://github.com/cedar-policy/prism-cedar)**  
+* **[prism-cedar](https://github.com/cedar-policy/prism-cedar)**
 Prism support for Cedar policy language
+* **[cedar-for-agents](https://github.com/cedar-policy/cedar-for-agents)**
+Code and software at the intersection of Cedar and agents.
 
 ## Code of Conduct
 
@@ -64,7 +66,7 @@ See [NOTICE](NOTICE) for details.
 
 ## Trademark
 
-Cedar is a trademark of Amazon Web Services. If publishing software using Cedar, you are not required to attribute. However, if you’d like to, we encourage you to use the language below.
+Cedar is a CNCF sandbox project. If publishing software using Cedar, you are not required to attribute. However, if you’d like to, we encourage you to use the language below.
 
 
 |Do:	|Don't:	|
@@ -72,5 +74,3 @@ Cedar is a trademark of Amazon Web Services. If publishing software using Cedar,
 |✅ Powered by Cedar	|❌ Cedar 2.0	|
 |✅ Created with Cedar	|❌ Created by Cedar	|
 |✅ Using Cedar	|❌ Software created by Cedar	|
-
-


### PR DESCRIPTION
Updates README with:
- remove the "trademark", this is a CNCF project.
- add reference to cedar-for-agents.

