### PR TITLE
update security contact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ information to effectively respond to your bug report or contribution.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
+If you think you have discovered a security issue related to Cedar, **please write to us** at [cedar-policy-security@lists.cncf.io ](mailto:cedar-policy-security@lists.cncf.io ); do **NOT** open a public issue. See [SECURITY](SECURITY.md).
 
 
 ## Reporting Bugs/Feature Requests

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -15,7 +15,7 @@ Maintainers are active and visible members of the community, and have [maintain-
 * Uphold Code of Conduct
 * Model the behavior set forward by the Code of Conduct and raise any violations to other maintainers and admins.
 * Prioritize Security
-* Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs. Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](https://github.com/opensearch-project/.github/blob/main/SECURITY.md) for details.
+* Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs. See [Reporting a Vulnerability](https://github.com/opensearch-project/.github/blob/main/SECURITY.md) for details.
 * Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests.
 *  Provide code reviews and guidance on incoming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
 * Triage Open Issues
@@ -25,6 +25,5 @@ Maintainers are active and visible members of the community, and have [maintain-
 * Maintain Overall Health of the Repo
 * Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches.
 * Keep Dependencies up to Date
-* Assist, add, and remove MAINTAINERS. 
-* Make sure the repo has a well-written, accurate, and complete description. 
-
+* Assist, add, and remove MAINTAINERS.
+* Make sure the repo has a well-written, accurate, and complete description.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,8 @@
 
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to [aws-security@amazon.com](mailto:aws-security@amazon.com). Please do not create a public GitHub issue.
+If you think you have discovered a security issue related to Cedar, **please write to us** at [cedar-policy-security@lists.cncf.io ](mailto:cedar-policy-security@lists.cncf.io ); do **NOT** open a public issue. Along with your notification email, please provide any supporting material (proof-of-concept code, tool output, etc.) that would be useful in helping us understand the nature and severity of the security concern.
+
+We will send a non-automated acknowledgement email reply within 1 business day followed by an initial assessment of the issue within 5 business days. Subsequently, we will work in partnership with you to assess any impact of the issue and prepare a security advisory (including any patches with appropriate fix) as needed.
+
+If we confirm that your report represents a security issue in Cedar, we will work with you to agree on an embargo period (typically at least 2 weeks AFTER any necessary development time) which will provide enough time to test our proposed fix and develop patches prior to any broader or more public disclosure. At the end of the embargo period, Cedar maintainers will publicly release information about the security issue together with the patches that mitigate it.

--- a/profile/NOTICE
+++ b/profile/NOTICE
@@ -1,1 +1,1 @@
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright The Cedar contributors.

--- a/profile/README.md
+++ b/profile/README.md
@@ -51,8 +51,7 @@ This project follows the [CNCF Code of Conduct](../CODE_OF_CONDUCT.md). For more
 
 ## Security
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to [aws-security@amazon.com](mailto:aws-security@amazon.com). Please do **not** create a public GitHub issue.
-
+If you think you have discovered a security issue in this project, **please write to us** at [cedar-policy-security@lists.cncf.io ](mailto:cedar-policy-security@lists.cncf.io ); do **NOT** open a public issue. See [SECURITY](SECURITY.md).
 
 ## License
 

--- a/profile/RESPONSIBILITIES.md
+++ b/profile/RESPONSIBILITIES.md
@@ -15,7 +15,7 @@ Maintainers are active and visible members of the community, and have [maintain-
 * Uphold Code of Conduct
 * Model the behavior set forward by the Code of Conduct and raise any violations to other maintainers and admins.
 * Prioritize Security
-* Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs. Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](https://github.com/opensearch-project/.github/blob/main/SECURITY.md) for details.
+* Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs. See [Reporting a Vulnerability](https://github.com/cedar-policy/.github/blob/main/SECURITY.md) for details.
 * Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests.
 *  Provide code reviews and guidance on incoming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
 * Triage Open Issues
@@ -25,6 +25,5 @@ Maintainers are active and visible members of the community, and have [maintain-
 * Maintain Overall Health of the Repo
 * Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches.
 * Keep Dependencies up to Date
-* Assist, add, and remove MAINTAINERS. 
-* Make sure the repo has a well-written, accurate, and complete description. 
-
+* Assist, add, and remove MAINTAINERS.
+* Make sure the repo has a well-written, accurate, and complete description.


### PR DESCRIPTION
Updates the SECURITY.md of this repository consistently with https://github.com/cedar-policy/.github/pull/28

Notice edit to be consistent with https://github.com/cncf/foundation/blob/main/copyright-notices.md


